### PR TITLE
Small bugfix for the Galaxy Nexus Phone (maguro) running android 4.3

### DIFF
--- a/src/info/mzimmermann/xposed/cputempstatusbar/CpuTemp.java
+++ b/src/info/mzimmermann/xposed/cputempstatusbar/CpuTemp.java
@@ -189,7 +189,11 @@ public class CpuTemp extends TextView implements OnSharedPreferenceChangeListene
 			String text = "";
 			int freq = Integer.parseInt(sFreq.toString().replaceAll("[^0-9]+", ""));
 			if(freqMode == 0) {
-				text=String.valueOf(freq);
+				if(freq > 1000){ //Minor bugfix for the Galaxy Nexus Phone (maguro)
+					text=String.valueOf(freq/1000f);	
+				} else {
+					text=String.valueOf(freq);				
+				}
 			}
 			else if(freqMode==1) {
 				text = String.valueOf(freq/10f);


### PR DESCRIPTION
In the Galaxy Nexus, the data pulled from the temperature file comes with lots of 0's, so it messes around with the value, as we can see in the picture below!
![bytusxuieaau1lf](https://f.cloud.github.com/assets/798026/1477159/2c56f0b0-4656-11e3-893b-ef75d25c1059.png)
