### PR TITLE
temperature handling tweaks

### DIFF
--- a/src/info/mzimmermann/xposed/cputempstatusbar/widget/CpuTemp.java
+++ b/src/info/mzimmermann/xposed/cputempstatusbar/widget/CpuTemp.java
@@ -143,16 +143,16 @@ public class CpuTemp extends TextView implements OnSharedPreferenceChangeListene
 			String sTemp = sbTemp.toString().replaceAll("[^0-9.]+", "");
 			float temp = Float.valueOf(sTemp);
 
+			// apply divider
+			int divider = Integer.parseInt(mContext.getSharedPreferences(PREF_KEY, 0).getString("temperature_divider", "1"));
+			if(divider!=0)
+				temp = temp/divider;
+			
 			// measure system
 			String measurement = mContext.getSharedPreferences(PREF_KEY, 0).getString("measurement", "C");
 			if(measurement.equals("F")){
 				temp = (temp * 9/5) + 32;
 			}
-			
-			// apply divider
-			int divider = Integer.parseInt(mContext.getSharedPreferences(PREF_KEY, 0).getString("temperature_divider", "1"));
-			if(divider!=0)
-				temp = temp/divider;
 			
 			// set text
 			boolean show_unit = mContext.getSharedPreferences(PREF_KEY, 0).getBoolean("show_unit", true);

--- a/src/info/mzimmermann/xposed/cputempstatusbar/widget/CpuTemp.java
+++ b/src/info/mzimmermann/xposed/cputempstatusbar/widget/CpuTemp.java
@@ -140,7 +140,7 @@ public class CpuTemp extends TextView implements OnSharedPreferenceChangeListene
 			fis.close();
 
 			// parse temp
-			String sTemp = sbTemp.toString().replaceAll("[^0-9]+", "");
+			String sTemp = sbTemp.toString().replaceAll("[^0-9.]+", "");
 			float temp = Float.valueOf(sTemp);
 
 			// measure system


### PR DESCRIPTION
2 fixes.

First, don't remove decimal points when parsing temperatures. One temperature file on my tablet varies between "33.0" and "33.25", which presently gets parsed as 330 and 3325, so the temperature jumps around wildly.

Second, processing divider before Fahrenheit conversion. Applying the divider afterward, as the present code does, gives wrong results.
